### PR TITLE
Fix MP3 metadata writing

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,6 @@
 mutagen
+requests
+musicbrainzngs
 Pillow
 python-dotenv
 pydub


### PR DESCRIPTION
## Summary
- fix MP3 metadata writing to add ID3 tags if missing
- save MP3s using ID3v2.3 and handle frames with `audio.tags.add`
- include requests and musicbrainzngs in requirements

## Testing
- `python test_metadata_enrichment.py`
- `python test_smart_playlists.py`


------
https://chatgpt.com/codex/tasks/task_e_684c154dd05c832e8a148b568751b375