### PR TITLE
Add service layer modules and unit tests

### DIFF
--- a/services/bpm_service.py
+++ b/services/bpm_service.py
@@ -1,0 +1,9 @@
+"""Service layer for BPM analysis independent of any UI framework."""
+from core.bpm_analyzer import analyze_track_bpm
+
+class BPMService:
+    """Wraps BPM analysis logic for easy consumption by higher layers."""
+
+    def analyze(self, file_path: str):
+        """Return BPM analysis result for the given audio file."""
+        return analyze_track_bpm(file_path)

--- a/services/metadata_service.py
+++ b/services/metadata_service.py
@@ -1,0 +1,9 @@
+"""Service layer for metadata enrichment independent of the GUI."""
+from core.metadata_enricher import enrich_metadata
+
+class MetadataService:
+    """Expose metadata enrichment without tying to a UI framework."""
+
+    def enrich(self, track_info: dict):
+        """Return enriched metadata for the given track info."""
+        return enrich_metadata(track_info)

--- a/tests/test_bpm_service.py
+++ b/tests/test_bpm_service.py
@@ -1,0 +1,32 @@
+import unittest
+import numpy as np
+import soundfile as sf
+import tempfile
+import os
+from services.bpm_service import BPMService
+
+class TestBPMService(unittest.TestCase):
+    def setUp(self):
+        sr = 22050
+        bpm = 120
+        duration = 5
+        click_times = np.arange(0, duration, 60 / bpm)
+        y = np.zeros(int(sr * duration))
+        click_samples = (click_times * sr).astype(int)
+        y[click_samples] = 1.0
+        fd, self.temp_path = tempfile.mkstemp(suffix='.wav')
+        os.close(fd)
+        sf.write(self.temp_path, y, sr)
+
+    def tearDown(self):
+        os.remove(self.temp_path)
+
+    def test_analyze_returns_bpm(self):
+        service = BPMService()
+        result = service.analyze(self.temp_path)
+        self.assertIn('bpm', result)
+        self.assertIsNotNone(result['bpm'])
+        self.assertTrue(110 <= result['bpm'] <= 130)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_metadata_service.py
+++ b/tests/test_metadata_service.py
@@ -1,0 +1,18 @@
+import unittest
+from unittest.mock import patch
+from services.metadata_service import MetadataService
+
+class TestMetadataService(unittest.TestCase):
+    @patch('core.metadata_enricher._search_musicbrainz', return_value={'genre': 'Rock'})
+    @patch('core.metadata_enricher._search_spotify', return_value={'year': 1990})
+    @patch('core.metadata_enricher._search_discogs', return_value={'album': 'Demo'})
+    def test_enrich_combines_sources(self, mock_d, mock_s, mock_mb):
+        service = MetadataService()
+        info = {'title': 'Test', 'artist': 'Band'}
+        result = service.enrich(info)
+        self.assertEqual(result['genre'], 'Rock')
+        self.assertEqual(result['year'], 1990)
+        self.assertEqual(result['album'], 'Demo')
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- add simple service layer modules to decouple business logic from GUI
- provide unit tests for the new services

## Testing
- `python3 run_tests.py` *(fails: ImportError: libEGL.so.1, missing dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_685218e2e450832eb6f706783851e376